### PR TITLE
fixing file finding on unix

### DIFF
--- a/perceive_ffind.m
+++ b/perceive_ffind.m
@@ -13,7 +13,23 @@ if ~rec
     if size(x,1)>1
         files = cellstr(ls(string));
     else
-        files = strsplit(x,' ');
+        % On unix, the output of 'ls' is a rich text, see the help for LS:
+        %  >> On UNIX, LS returns a character row vector of filenames
+        %  >> separated by tab and space characters.
+        % On top of that, the text terminates with a newline.
+        % Therefore, we can't split only on spaces, but also on tabs and newlines:
+        files = strsplit(x);
+        % On unix, splitting on newlines can result in the last entry being empty,
+        % so we remove empty entries:
+        if ~isempty(files)
+            nonempty=repmat(true,1,length(files));
+            for i=1:length(files)
+                if isempty(files{i})
+                    nonempty(i)=false;
+                end
+            end
+            files=files(nonempty);
+        end
     end
     
     for a =1:length(files)


### PR DESCRIPTION
Hi, reading files did not work for me on linux, as `ls` resulted in a `files`variable with a trailing newline, which couldn't be read by `jsondecode(fileread(...))`. 
I propose a PR for unix, which, however, hasn't been tested on windows. 
Thanks for your consideration, and also for sharing your `perceive` code!