### PR TITLE
Close excessive figures

### DIFF
--- a/perceive_plot_raw_signals.m
+++ b/perceive_plot_raw_signals.m
@@ -14,7 +14,11 @@ for a=1:length(files)
     end
     
     if isstruct(data)
-        time = data.time{1};
+        if isfield(data,'realtime')
+            time = data.realtime{1};
+        else
+            time = data.time{1};
+        end
         chanlabels = data.label;
         fname = data.fname;
         fs = data.fsample;


### PR DESCRIPTION
Since the number of LfpTrendLogs can be quite high (hundreds, at least), we may want not to keep all the created figures open to save OS resources. Otherwise, the graphic resources would get exhausted and no new figure would get created (at least on X11 system on linux), where I experience the following error:
```
  Maximum number of clients reached
  Exception in thread "AWT-EventQueue-0": com.jogamp.nativewindow.NativeWindowException:
  X11Util.Display: Unable to create a display(:1) connection.
```