### PR TITLE
Empty datetime arrays

### DIFF
--- a/perceive.m
+++ b/perceive.m
@@ -258,8 +258,8 @@ for a = 1:length(files)
                     end
                 case 'DiagnosticData'
                     if isfield(data,'LFPTrendLogs')
-                          LFPL=[];STIML=[];DTL=[];
-                            LFPR=[];STIMR=[];DTR=[]; 
+                          LFPL=[];STIML=[];DTL=datetime([],[],[]);
+                            LFPR=[];STIMR=[];DTR=datetime([],[],[]);
                         if isfield(data.LFPTrendLogs,'HemisphereLocationDef_Left')
                             data.left=data.LFPTrendLogs.HemisphereLocationDef_Left;
                             runs = fieldnames(data.left);          

--- a/perceive_plot_raw_signals.m
+++ b/perceive_plot_raw_signals.m
@@ -15,9 +15,9 @@ for a=1:length(files)
     
     if isstruct(data)
         if isfield(data,'realtime')
-            try
+            if iscell(data.realtime)
                 time = data.realtime{1};
-            catch
+            else
                 time = data.realtime;
             end
         else


### PR DESCRIPTION
When left / right side is missing and DTL or DTR is set to `[]`, `setdiff(DTR,DTL)])` fails:

```
Comparison is not defined between datetime and double arrays.
Error in perceive (line 323)
                        DT=sort([DTL,setdiff(DTR,DTL)]);
```

Fixed with initializing the empty arrays with `datetime([],[],[])`, not `[]`.